### PR TITLE
The 4th condition implementation and test. 

### DIFF
--- a/src/main/java/com/dd2480/CMV/impl/ConditionFour.java
+++ b/src/main/java/com/dd2480/CMV/impl/ConditionFour.java
@@ -1,0 +1,78 @@
+package com.dd2480.CMV.impl;
+
+import com.dd2480.CMV.Condition;
+import com.dd2480.CMV.ConditionContext;
+import com.dd2480.common.Point;
+import com.dd2480.common.PointCollection;
+import com.dd2480.common.Parameters;
+
+import java.util.HashSet;
+import java.util.Set;
+
+/*
+ * There exists at least one set of Q_PTS consecutive data points that lie in more than QUADS
+ * quadrants. Where there is ambiguity as to which quadrant contains a given point, priority
+ * of decision will be by quadrant number, i.e., I, II, III, IV. For example, the data point (0,0)
+ * is in quadrant I, the point (-l,0) is in quadrant II, the point (0,-l) is in quadrant III, the point
+ * (0,1) is in quadrant I and the point (1,0) is in quadrant I.
+ * (2 ≤ Q PTS ≤ NUMPOINTS), (1 ≤ QUADS ≤ 3)
+ */
+public class ConditionFour implements Condition {
+    @Override
+    public boolean evaluate(ConditionContext conditionContext) {
+        PointCollection pointCollection = conditionContext.getPointCollection();
+        Parameters params = conditionContext.getParameters();
+        int qPts = params.getQPTS();
+        int quads = params.getQUADS();
+
+        // Invalid if the number of points less than Q_PTS
+        if (pointCollection.size() < qPts) {
+            return false;
+        }
+
+        // Traverse all consecutive Q_PTS points
+        for (int i = 0; i <= pointCollection.size() - qPts; ++i) {
+            Set<Integer> quadrants = new HashSet<>();
+
+            // Check the quadrant of the current Q_PTS points
+            for (int j = 0; j < qPts; ++j) {
+                Point point = pointCollection.getPoint(i + j);
+                int quadrant = getQuadrant(point);
+                quadrants.add(quadrant);
+            }
+
+            // Meet the condition if the number of quadrants is greater than QUADS
+            if (quadrants.size() > quads) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    // Determine the quadrant of a point according to its coordinates
+    private int getQuadrant(Point point) {
+        double x = point.getX();
+        double y = point.getY();
+
+        if (x > 0 && y > 0) {
+            return 1; // 1st Quadrant
+        } else if (x < 0 && y > 0) {
+            return 2; // 2nd Quadrant
+        } else if (x < 0 && y < 0) {
+            return 3; // 3rd Quadrant
+        } else if (x > 0 && y < 0) {
+            return 4; // 4th Quadrant
+        } else if (x == 0 && y > 0) {
+            return 1; // Borderline cases are classified as the 1st quadrant
+        } else if (x < 0 && y == 0) {
+            return 2; // Borderline cases are classified as the 2nd quadrant
+        } else if (x == 0 && y < 0) {
+            return 3; // Borderline cases are classified as the 3rd quadrant
+        } else if (x > 0 && y == 0) {
+            return 1; // Borderline cases are classified as the 1st quadrant
+        } else {
+            return 1; // (0, 0) is classified as the 1st quadrant
+        }
+    }
+}

--- a/src/main/java/com/dd2480/common/Parameters.java
+++ b/src/main/java/com/dd2480/common/Parameters.java
@@ -24,8 +24,8 @@ public class Parameters {
 
     // Constructor
     public Parameters(double LENGTH1, double RADIUS1, double EPSILON, double AREA1, int Q_PTS, int QUADS,
-                      double DIST, int N_PTS, int K_PTS, int A_PTS, int B_PTS, int C_PTS,
-                      int D_PTS, int E_PTS, int F_PTS, double LENGTH2, double RADIUS2, double AREA2) {
+            double DIST, int N_PTS, int K_PTS, int A_PTS, int B_PTS, int C_PTS,
+            int D_PTS, int E_PTS, int F_PTS, double LENGTH2, double RADIUS2, double AREA2) {
         this.LENGTH1 = LENGTH1;
         this.RADIUS1 = RADIUS1;
         this.EPSILON = EPSILON;
@@ -63,6 +63,14 @@ public class Parameters {
         return AREA1;
     }
 
+    public int getQPTS() {
+        return Q_PTS;
+    }
+
+    public int getQUADS() {
+        return QUADS;
+    }
+
     // Private constructor, only accessible via the builder
     private Parameters(Builder builder) {
         this.LENGTH1 = builder.LENGTH1;
@@ -86,24 +94,24 @@ public class Parameters {
     }
 
     public static class Builder {
-        private double LENGTH1 = 0.0;  // Default value
-        private double RADIUS1 = 0.0;  // Default value
-        private double EPSILON = 0.0;  // Default value
-        private double AREA1 = 0.0;    // Default value
-        private int Q_PTS = 0;         // Default value
-        private int QUADS = 0;         // Default value
-        private double DIST = 0.0;     // Default value
-        private int N_PTS = 0;         // Default value
-        private int K_PTS = 0;         // Default value
-        private int A_PTS = 0;         // Default value
-        private int B_PTS = 0;         // Default value
-        private int C_PTS = 0;         // Default value
-        private int D_PTS = 0;         // Default value
-        private int E_PTS = 0;         // Default value
-        private int F_PTS = 0;         // Default value
-        private double LENGTH2 = 0.0;  // Default value
-        private double RADIUS2 = 0.0;  // Default value
-        private double AREA2 = 0.0;    // Default value
+        private double LENGTH1 = 0.0; // Default value
+        private double RADIUS1 = 0.0; // Default value
+        private double EPSILON = 0.0; // Default value
+        private double AREA1 = 0.0; // Default value
+        private int Q_PTS = 0; // Default value
+        private int QUADS = 0; // Default value
+        private double DIST = 0.0; // Default value
+        private int N_PTS = 0; // Default value
+        private int K_PTS = 0; // Default value
+        private int A_PTS = 0; // Default value
+        private int B_PTS = 0; // Default value
+        private int C_PTS = 0; // Default value
+        private int D_PTS = 0; // Default value
+        private int E_PTS = 0; // Default value
+        private int F_PTS = 0; // Default value
+        private double LENGTH2 = 0.0; // Default value
+        private double RADIUS2 = 0.0; // Default value
+        private double AREA2 = 0.0; // Default value
 
         // Method to set LENGTH1 and return the builder for method chaining
         public Builder setLENGTH1(double LENGTH1) {
@@ -126,7 +134,7 @@ public class Parameters {
         // ... (other setter methods for remaining fields)
 
         public Parameters build() {
-            return new Parameters(this);  // Return the fully constructed Parameters object
+            return new Parameters(this); // Return the fully constructed Parameters object
         }
         // Continue with other getters...
     }

--- a/src/test/java/com/dd2480/CMV/impl/ConditionFourTest.java
+++ b/src/test/java/com/dd2480/CMV/impl/ConditionFourTest.java
@@ -1,0 +1,85 @@
+package com.dd2480.CMV.impl;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.*;
+
+import com.dd2480.CMV.ConditionContext;
+import com.dd2480.common.Parameters;
+import com.dd2480.common.Point;
+import com.dd2480.common.PointCollection;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class ConditionFourTest {
+
+    private ConditionFour conditionFour;
+    private ConditionContext conditionContext;
+
+    @BeforeEach
+    public void setUp() {
+        conditionFour = new ConditionFour();
+        conditionContext = mock(ConditionContext.class);
+    }
+
+    @Test
+    public void testEvaluate_conditionMet() {
+        Parameters params = mock(Parameters.class);
+        PointCollection pointCollection = new PointCollection();
+
+        // Add points, distributed in 3 quadrants
+        pointCollection.addPoint(new Point(1.0, 1.0)); // 1st Quadrant
+        pointCollection.addPoint(new Point(-1.0, 1.0)); // 2nd Quadrant
+        pointCollection.addPoint(new Point(-1.0, -1.0)); // 3rd Quadrant
+        when(conditionContext.getParameters()).thenReturn(params);
+        when(conditionContext.getPointCollection()).thenReturn(pointCollection);
+
+        // Set Q_PTS = 3，QUADS = 2
+        when(params.getQPTS()).thenReturn(3);
+        when(params.getQUADS()).thenReturn(2);
+
+        // Meet the condition
+        boolean result = conditionFour.evaluate(conditionContext);
+        assertTrue(result);
+    }
+
+    @Test
+    public void testEvaluate_conditionNotMet() {
+        Parameters params = mock(Parameters.class);
+        PointCollection pointCollection = new PointCollection();
+
+        // Add points, distributed in the same quadrant
+        pointCollection.addPoint(new Point(1.0, 1.0)); // 1st Quadrant
+        pointCollection.addPoint(new Point(2.0, 2.0)); // 1st Quadrant
+        pointCollection.addPoint(new Point(3.0, 3.0)); // 1st Quadrant
+        when(conditionContext.getParameters()).thenReturn(params);
+        when(conditionContext.getPointCollection()).thenReturn(pointCollection);
+
+        // Set Q_PTS = 3，QUADS = 2
+        when(params.getQPTS()).thenReturn(3);
+        when(params.getQUADS()).thenReturn(2);
+
+        // Do NOT meet the condition
+        boolean result = conditionFour.evaluate(conditionContext);
+        assertFalse(result);
+    }
+
+    @Test
+    public void testEvaluate_insufficientPoints() {
+        Parameters params = mock(Parameters.class);
+        PointCollection pointCollection = new PointCollection();
+
+        // Add points less than Q_PTS
+        pointCollection.addPoint(new Point(1.0, 1.0));
+        when(conditionContext.getParameters()).thenReturn(params);
+        when(conditionContext.getPointCollection()).thenReturn(pointCollection);
+
+        // Set Q_PTS = 3，QUADS = 2
+        when(params.getQPTS()).thenReturn(3);
+        when(params.getQUADS()).thenReturn(2);
+
+        // Do NOT meet the condition
+        boolean result = conditionFour.evaluate(conditionContext);
+        assertFalse(result);
+    }
+}


### PR DESCRIPTION
### The 4th condition implementation
There exists at least one set of Q_PTS consecutive data points that lie in more than QUADS quadrants. Where there is ambiguity as to which quadrant contains a given point, priority of decision will be by quadrant number, i.e., I, II, III, IV. For example, the data point (0,0) is in quadrant I, the point (-l,0) is in quadrant II, the point (0,-l) is in quadrant III, the point (0,1) is in quadrant I and the point (1,0) is in quadrant I.
(2 $\leq$ Q_PTS $\leq$ NUMPOINTS), (1 $\leq$ QUADS $\leq$ 3)

Add two interfaces, **_getQPTS()_** and **_getQUADS()_**, which returns Q_PTS and QUADS respectively.