### PR TITLE
feat: Implement 12th condition and tests, add getLENGTH2() interface (#26)

### DIFF
--- a/src/main/java/com/dd2480/CMV/impl/ConditionTwelve.java
+++ b/src/main/java/com/dd2480/CMV/impl/ConditionTwelve.java
@@ -1,0 +1,78 @@
+package com.dd2480.CMV.impl;
+
+import com.dd2480.CMV.ConditionContext;
+import com.dd2480.CMV.Condition;
+import com.dd2480.common.Point;
+import com.dd2480.common.PointCollection;
+import com.dd2480.common.Parameters;
+
+/*
+ * There exists at least one set of two data points, separated by exactly K PTS consecutive
+ * intervening points, which are a distance greater than the length, LENGTH1, apart. 
+ * In addition, there exists at least one set of two data points (which can be the same 
+ * or different from the two data points just mentioned), separated by exactly K_PTS 
+ * consecutive intervening points, that are a distance less than the length, LENGTH2, apart. 
+ * Both parts must be true for the LIC to be true. The condition is not met when NUMPOINTS < 3.
+ * 0 <= LENGTH2
+ */
+public class ConditionTwelve implements Condition {
+    /*
+     * Condition A: There exists at least one pair of points separated by exactly
+     * KPTS
+     * such that the distance between the points is greater than LENGTH1.
+     * 
+     * Condition B: There exists at least one pair of points (possibly the same or
+     * different from Condition A) separated by exactly KPTS such that the distance
+     * between the points is less than LENGTH2.
+     */
+    @Override
+    public boolean evaluate(ConditionContext conditionContext) {
+        PointCollection pointCollection = conditionContext.getPointCollection();
+        Parameters params = conditionContext.getParameters();
+        int kPts = params.getKPTS();
+        double length1 = params.getLENGTH1(); // Distance threshold for Condition A
+        double length2 = params.getLENGTH2(); // Distance threshold for Condition B
+
+        // Invalid if NUMPOINTS < 3 or KPTS is out of range
+        if (pointCollection.size() < 3 || kPts < 0 || kPts > pointCollection.size() - 2 || length2 < 0) {
+            return false;
+        }
+
+        boolean conditionA = false; // Distance > LENGTH1
+        boolean conditionB = false; // Distance < LENGTH2
+
+        // Traverse all valid pairs of points
+        for (int i = 0; i < pointCollection.size() - kPts - 1; ++i) {
+            Point p1 = pointCollection.getPoint(i); // The 1st point
+            Point p2 = pointCollection.getPoint(i + kPts + 1); // The 2nd point
+
+            // Calculate the distance between the points
+            double distance = euclideanDistance(p1, p2);
+
+            // Check Condition A
+            if (distance > length1) {
+                conditionA = true;
+            }
+
+            // Check Condition B
+            if (distance < length2) {
+                conditionB = true;
+            }
+
+            // If both conditions are satisfied, return true
+            if (conditionA && conditionB) {
+                return true;
+            }
+        }
+
+        // If either condition is not satisfied, return false
+        return false;
+    }
+
+    // Calculates the Euclidean distance between two points.
+    private double euclideanDistance(Point p1, Point p2) {
+        double dx = p2.getX() - p1.getX();
+        double dy = p2.getY() - p1.getY();
+        return Math.sqrt(dx * dx + dy * dy);
+    }
+}

--- a/src/main/java/com/dd2480/common/Parameters.java
+++ b/src/main/java/com/dd2480/common/Parameters.java
@@ -113,6 +113,10 @@ public class Parameters {
         return G_PTS;
     }
 
+    public double getLENGTH2() {
+        return LENGTH2;
+    }
+
     // Private constructor, only accessible via the builder
     private Parameters(Builder builder) {
         this.LENGTH1 = builder.LENGTH1;

--- a/src/test/java/com/dd2480/CMV/impl/ConditionTwelveTest.java
+++ b/src/test/java/com/dd2480/CMV/impl/ConditionTwelveTest.java
@@ -1,0 +1,97 @@
+package com.dd2480.CMV.impl;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.*;
+
+import com.dd2480.CMV.ConditionContext;
+import com.dd2480.common.Parameters;
+import com.dd2480.common.Point;
+import com.dd2480.common.PointCollection;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class ConditionTwelveTest {
+
+    private ConditionTwelve conditionTwelve;
+    private ConditionContext conditionContext;
+
+    @BeforeEach
+    public void setUp() {
+        conditionTwelve = new ConditionTwelve();
+        conditionContext = mock(ConditionContext.class);
+    }
+
+    @Test
+    public void testEvaluate_conditionMet() {
+        Parameters params = mock(Parameters.class);
+        PointCollection pointCollection = new PointCollection();
+
+        // Add points satisfying both conditions
+        pointCollection.addPoint(new Point(0.0, 0.0)); // P1
+        pointCollection.addPoint(new Point(1.0, 1.0)); // Intermediate point
+        pointCollection.addPoint(new Point(5.0, 5.0)); // P2 (distance > LENGTH1)
+        pointCollection.addPoint(new Point(3.0, 3.0)); // Intermediate point
+        pointCollection.addPoint(new Point(3.5, 3.5)); // P3 (distance < LENGTH2)
+        when(conditionContext.getParameters()).thenReturn(params);
+        when(conditionContext.getPointCollection()).thenReturn(pointCollection);
+
+        // Set K_PTS = 1, LENGTH1 = 3.0, LENGTH2 = 2.5
+        when(params.getKPTS()).thenReturn(1);
+        when(params.getLENGTH1()).thenReturn(3.0);
+        when(params.getLENGTH2()).thenReturn(2.5);
+
+        // Evaluate the condition
+        boolean result = conditionTwelve.evaluate(conditionContext);
+
+        // Meet the condition
+        assertTrue(result);
+    }
+
+    @Test
+    public void testEvaluate_conditionNotMet() {
+        Parameters params = mock(Parameters.class);
+        PointCollection pointCollection = new PointCollection();
+
+        // Add points not satisfying both conditions
+        pointCollection.addPoint(new Point(0.0, 0.0)); // P1
+        pointCollection.addPoint(new Point(1.0, 1.0)); // Intermediate point
+        pointCollection.addPoint(new Point(2.0, 2.0)); // P2
+        when(conditionContext.getParameters()).thenReturn(params);
+        when(conditionContext.getPointCollection()).thenReturn(pointCollection);
+
+        // Set K_PTS = 1, LENGTH1 = 5.0, LENGTH2 = 3.0
+        when(params.getKPTS()).thenReturn(1);
+        when(params.getLENGTH1()).thenReturn(5.0); // distance < LENGTH1 (condition A false)
+        when(params.getLENGTH2()).thenReturn(3.0); // distance < LENGTH2 (condition B true)
+
+        // Evaluate the condition
+        boolean result = conditionTwelve.evaluate(conditionContext);
+
+        // Do NOT meet the condition
+        assertFalse(result);
+    }
+
+    @Test
+    public void testEvaluate_insufficientPoints() {
+        Parameters params = mock(Parameters.class);
+        PointCollection pointCollection = new PointCollection();
+
+        // Add fewer than 3 points
+        pointCollection.addPoint(new Point(0.0, 0.0));
+        pointCollection.addPoint(new Point(1.0, 1.0));
+        when(conditionContext.getParameters()).thenReturn(params);
+        when(conditionContext.getPointCollection()).thenReturn(pointCollection);
+
+        // Set K_PTS = 1, LENGTH1 = 3.0, LENGTH2 = 1.5
+        when(params.getKPTS()).thenReturn(1);
+        when(params.getLENGTH1()).thenReturn(3.0);
+        when(params.getLENGTH2()).thenReturn(1.5);
+
+        // Evaluate the condition
+        boolean result = conditionTwelve.evaluate(conditionContext);
+
+        // Do NOT meet the condition
+        assertFalse(result);
+    }
+}


### PR DESCRIPTION
### Description
This Pull Request implements the 12th condition as outlined in the project requirements and adds the `getLENGTH2()` interface. It resolves #26.

### Changes
- Added implementation for the 12th condition:
  - The condition checks for specific relationships between data points (detailed logic described in the code).
- Added a new method `getLENGTH2()` to `Parameters.java` to support the 12th condition.
- Updated the test suite with:
  - Positive cases to verify the condition is satisfied under valid inputs.
  - Negative cases to ensure it fails with invalid inputs.

### Resolves
- #26

### Tests
The following test cases were added (refer to the code for detailed implementation):
-  **Positive case**: 
   - Five points in total, which satisfied the condition.
- **Negative case**: Invalid inputs where the 12th condition should fail.
   - Three points in total, which satisfied the second condition while not satisfied the first.
   - Two points in total, which not satisfied NUMPOINTS $\geq$ 3. 

### Notes for Reviewers
- Please verify the correctness of the condition logic and ensure the new `getLENGTH2()` interface is correctly implemented.
- Feedback on edge case coverage in the tests is appreciated.