### PR TITLE
fix Call method pumManager.computePUM() and method fuvManager.compute…

### DIFF
--- a/src/main/java/com/dd2480/App.java
+++ b/src/main/java/com/dd2480/App.java
@@ -74,9 +74,11 @@ public class App {
             CMV cmv = evaluateCMV(conditionContext);
 
             PUMManager pumManager = new PUMManagerImpl(cmv, lcm);
+            pumManager.computePUM();
             PUM pum = pumManager.getPUM();
 
             FUVManager fuvManager = new FUVManagerImpl(pum, puv);
+            fuvManager.computeFUV();
             FUV fuv = fuvManager.getFUV();
 
             if (launch(fuv)) {


### PR DESCRIPTION
## Description
In Main function, the method computePUM() and method computeFUV() are called .

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Other (please describe)

## How Has This Been Tested?
Please describe the testing that has been done on the changes. Include the testing environment, and any relevant details or configurations.

- [ ] Unit tests
- [ ] Integration tests
- [x] Manual testing



## Related Issues
#58 #4 #



## Additional Notes
The compute() methods should be called before get() methods are called.
