### PR TITLE
Reduces code duplication for LIC calculations

### DIFF
--- a/src/main/java/com/dd2480/CMV/impl/ConditionFourteen.java
+++ b/src/main/java/com/dd2480/CMV/impl/ConditionFourteen.java
@@ -4,6 +4,7 @@ import com.dd2480.CMV.ConditionContext;
 import com.dd2480.CMV.Condition;
 import com.dd2480.common.Point;
 import com.dd2480.common.PointCollection;
+import com.dd2480.common.CalculationUtils;
 import com.dd2480.common.Parameters;
 
 /*
@@ -41,7 +42,7 @@ public class ConditionFourteen implements Condition {
             Point p2 = pointCollection.getPoint(i + ePts + 1); 
             Point p3 = pointCollection.getPoint(i + ePts + fPts + 2); 
 
-            double area = calculateTriangleArea(p1, p2, p3);
+            double area = CalculationUtils.calculateTriangleArea(p1, p2, p3);
 
             // Check for both conditions
             if (area > area1) {
@@ -58,12 +59,5 @@ public class ConditionFourteen implements Condition {
         }
 
         return false;
-    }
-
-    private double calculateTriangleArea(Point p1, Point p2, Point p3) {
-        return 0.5 * Math.abs(
-                p1.getX() * (p2.getY() - p3.getY()) +
-                p2.getX() * (p3.getY() - p1.getY()) +
-                p3.getX() * (p1.getY() - p2.getY()));
     }
 }

--- a/src/main/java/com/dd2480/CMV/impl/ConditionNine.java
+++ b/src/main/java/com/dd2480/CMV/impl/ConditionNine.java
@@ -4,6 +4,7 @@ import com.dd2480.CMV.ConditionContext;
 import com.dd2480.CMV.Condition;
 import com.dd2480.common.Point;
 import com.dd2480.common.PointCollection;
+import com.dd2480.common.CalculationUtils;
 import com.dd2480.common.Parameters;
 
 /*
@@ -47,7 +48,7 @@ public class ConditionNine implements Condition {
             }
 
             // Calculate the angle formed at the vertex
-            double angle = calculateAngle(p1, p2, p3);
+            double angle = CalculationUtils.calculateAngle(p1, p2, p3);
 
             // Check if the angle meets the condition
             if (angle < Math.PI - epsilon || angle > Math.PI + epsilon) {
@@ -56,33 +57,5 @@ public class ConditionNine implements Condition {
         }
 
         return false;
-    }
-
-    // Calculates the angle formed by three points (p1, p2, p3) where p2 is the
-    // vertex.
-    private double calculateAngle(Point p1, Point p2, Point p3) {
-        // Vectors from the vertex to the other two points
-        double v1x = p1.getX() - p2.getX();
-        double v1y = p1.getY() - p2.getY();
-        double v2x = p3.getX() - p2.getX();
-        double v2y = p3.getY() - p2.getY();
-
-        // Calculate the dot product and magnitudes of the vectors
-        double dotProduct = (v1x * v2x) + (v1y * v2y);
-        double magnitudeV1 = Math.sqrt(v1x * v1x + v1y * v1y);
-        double magnitudeV2 = Math.sqrt(v2x * v2x + v2y * v2y);
-
-        // If either vector has zero length, the angle is undefined
-        if (magnitudeV1 == 0 || magnitudeV2 == 0) {
-            return Double.NaN;
-        }
-
-        // Calculate the cosine of the angle
-        double cosAngle = dotProduct / (magnitudeV1 * magnitudeV2);
-
-        // Ensure the cosine value is within the valid range [-1, 1]
-        cosAngle = Math.max(-1.0, Math.min(1.0, cosAngle));
-
-        return Math.acos(cosAngle);
     }
 }

--- a/src/main/java/com/dd2480/CMV/impl/ConditionTen.java
+++ b/src/main/java/com/dd2480/CMV/impl/ConditionTen.java
@@ -4,6 +4,7 @@ import com.dd2480.CMV.ConditionContext;
 import com.dd2480.CMV.Condition;
 import com.dd2480.common.Point;
 import com.dd2480.common.PointCollection;
+import com.dd2480.common.CalculationUtils;
 import com.dd2480.common.Parameters;
 
 /*
@@ -34,7 +35,7 @@ public class ConditionTen implements Condition {
             Point p3 = pointCollection.getPoint(i + ePts + fPts + 2); // Third point
 
             // Calculate the area of the triangle formed by the three points
-            double area = calculateTriangleArea(p1, p2, p3);
+            double area = CalculationUtils.calculateTriangleArea(p1, p2, p3);
 
             // Check if the area exceeds AREA1
             if (area > area1) {
@@ -43,14 +44,5 @@ public class ConditionTen implements Condition {
         }
 
         return false;
-    }
-
-    // Calculates the area of a triangle given its three vertices.
-    private double calculateTriangleArea(Point p1, Point p2, Point p3) {
-        // Formula: area = 1/2 * |x_1*(y_2-y_3) + x_2*(y_3-y_1) + x_3*(y_1-y2)|
-        return 0.5 * Math.abs(
-                p1.getX() * (p2.getY() - p3.getY()) +
-                        p2.getX() * (p3.getY() - p1.getY()) +
-                        p3.getX() * (p1.getY() - p2.getY()));
     }
 }

--- a/src/main/java/com/dd2480/CMV/impl/ConditionThree.java
+++ b/src/main/java/com/dd2480/CMV/impl/ConditionThree.java
@@ -4,6 +4,7 @@ import com.dd2480.CMV.Condition;
 import com.dd2480.CMV.ConditionContext;
 import com.dd2480.common.Point;
 import com.dd2480.common.PointCollection;
+import com.dd2480.common.CalculationUtils;
 import com.dd2480.common.Parameters;
 
 /*
@@ -29,7 +30,7 @@ public class ConditionThree implements Condition {
             Point p3 = pointCollection.getPoint(i + 1);
 
             // Calculate the triangle area
-            double area = calculateTriangleArea(p1, p2, p3);
+            double area = CalculationUtils.calculateTriangleArea(p1, p2, p3);
 
             // Meet the condition if area > AREA1
             if (area > area1) {
@@ -38,13 +39,5 @@ public class ConditionThree implements Condition {
         }
 
         return false;
-    }
-
-    // Calculate the area of ​​a triangle using the cross product method
-    private double calculateTriangleArea(Point p1, Point p2, Point p3) {
-        return 0.5 * Math.abs(
-                p1.getX() * (p2.getY() - p3.getY()) +
-                        p2.getX() * (p3.getY() - p1.getY()) +
-                        p3.getX() * (p1.getY() - p2.getY()));
     }
 }

--- a/src/main/java/com/dd2480/CMV/impl/ConditionTwo.java
+++ b/src/main/java/com/dd2480/CMV/impl/ConditionTwo.java
@@ -2,6 +2,7 @@ package com.dd2480.CMV.impl;
 
 import com.dd2480.CMV.Condition;
 import com.dd2480.CMV.ConditionContext;
+import com.dd2480.common.CalculationUtils;
 import com.dd2480.common.Parameters;
 import com.dd2480.common.Point;
 import com.dd2480.common.PointCollection;
@@ -36,7 +37,7 @@ public class ConditionTwo implements Condition {
             }
 
             // Calculate angle
-            double angle = calculateAngle(p1, p2, p3);
+            double angle = CalculationUtils.calculateAngle(p1, p2, p3);
 
             // Check if the angle meets the conditions
             if (angle < Math.PI - epsilon || angle > Math.PI + epsilon) {
@@ -45,34 +46,5 @@ public class ConditionTwo implements Condition {
         }
 
         return false; // All points do not meet the conditions
-    }
-
-    // Calculate the angle with p2 as the vertex
-    private double calculateAngle(Point p1, Point p2, Point p3) {
-        // Vector v1 and v2
-        double v1x = p1.getX() - p2.getX();
-        double v1y = p1.getY() - p2.getY();
-        double v2x = p3.getX() - p2.getX();
-        double v2y = p3.getY() - p2.getY();
-
-        // Calculate the dot product and magnitude of vectors
-        double dotProduct = (v1x * v2x) + (v1y * v2y);
-        double magnitudeV1 = Math.sqrt(v1x * v1x + v1y * v1y);
-        double magnitudeV2 = Math.sqrt(v2x * v2x + v2y * v2y);
-
-        // Invalid if the modulus is 0
-        if (magnitudeV1 == 0 || magnitudeV2 == 0) {
-            return Double.NaN;
-        }
-
-        // Calculates the cosine of the angle
-        double cosAngle = dotProduct / (magnitudeV1 * magnitudeV2);
-
-        // Ensures that the cosine is in the range [-1, 1]
-        cosAngle = Math.max(-1.0, Math.min(1.0, cosAngle));
-
-        // System.out.println(cosAngle);
-
-        return Math.acos(cosAngle);
     }
 }

--- a/src/main/java/com/dd2480/common/CalculationUtils.java
+++ b/src/main/java/com/dd2480/common/CalculationUtils.java
@@ -37,4 +37,32 @@ public class CalculationUtils {
                 p2.getX() * (p3.getY() - p1.getY()) +
                 p3.getX() * (p1.getY() - p2.getY()));
     }
+
+    // Calculates the angle formed by three points (p1, p2, p3) where p2 is the
+    // vertex.
+    public static double calculateAngle(Point p1, Point p2, Point p3) {
+        // Vectors from the vertex to the other two points
+        double v1x = p1.getX() - p2.getX();
+        double v1y = p1.getY() - p2.getY();
+        double v2x = p3.getX() - p2.getX();
+        double v2y = p3.getY() - p2.getY();
+
+        // Calculate the dot product and magnitudes of the vectors
+        double dotProduct = (v1x * v2x) + (v1y * v2y);
+        double magnitudeV1 = Math.sqrt(v1x * v1x + v1y * v1y);
+        double magnitudeV2 = Math.sqrt(v2x * v2x + v2y * v2y);
+
+        // If either vector has zero length, the angle is undefined
+        if (magnitudeV1 == 0 || magnitudeV2 == 0) {
+            return Double.NaN;
+        }
+
+        // Calculate the cosine of the angle
+        double cosAngle = dotProduct / (magnitudeV1 * magnitudeV2);
+
+        // Ensure the cosine value is within the valid range [-1, 1]
+        cosAngle = Math.max(-1.0, Math.min(1.0, cosAngle));
+
+        return Math.acos(cosAngle);
+    }
 }

--- a/src/main/java/com/dd2480/common/CalculationUtils.java
+++ b/src/main/java/com/dd2480/common/CalculationUtils.java
@@ -30,4 +30,11 @@ public class CalculationUtils {
                         p2.getX() * (p3.getY() - p1.getY()) +
                         p3.getX() * (p1.getY() - p2.getY())) / 2.0) < 1e-6; // threshold
     }
+
+    public static double calculateTriangleArea(Point p1, Point p2, Point p3) {
+        return 0.5 * Math.abs(
+                p1.getX() * (p2.getY() - p3.getY()) +
+                p2.getX() * (p3.getY() - p1.getY()) +
+                p3.getX() * (p1.getY() - p2.getY()));
+    }
 }


### PR DESCRIPTION
## Description
- Moves method `calculateTriangleArea()` to common utility CalculationUtils
- Moves method `calculateAngle()` to common utility CalculationUtils

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [x] Refactor
- [ ] Other (please describe)

## How Has This Been Tested?
- [x] Unit tests
- [ ] Integration tests
- [ ] Manual testing

## Related Issues

- Closes #68 
- Closes #69 
