### PR TITLE
Feat/63 user specifies path to input file

### DIFF
--- a/doc/maven_commands.md
+++ b/doc/maven_commands.md
@@ -18,5 +18,15 @@ mvn -Dtest=ClassName test
 
 # run the program
 ```shell
-mvn exec:java
+mvn exec:java 
 ```
+
+### For linux/macOS:
+```shell
+For mvn exec:java -Dexec.args="src/test/resources/test_input1.json"
+```
+
+### For windows:
+```shell
+ mvn exec:java -D"exec.args"="src\test\resources\test_input1.json"
+ ```

--- a/src/main/java/com/dd2480/App.java
+++ b/src/main/java/com/dd2480/App.java
@@ -50,13 +50,24 @@ import com.dd2480.common.Parameters;
  *
  */
 public class App {
+    /*
+     * Usage lin/mac: mvn exec:java -Dexec.args="src/test/resources/test_input1.json"
+     * usage windows: mvn exec:java -D"exec.args"="src\test\resources\test_input1.json"
+     * 
+     */
     public static void main(String[] args) {
-        decide();
+        if (args.length < 1) {
+            System.err.println("Usage linux/mac: mvn exec:java -Dexec.args=\"path/to/input.json\", usage windows: mvn exec:java -D\"exec.args\"=\"path\\to\\input.json\""); 
+            return;
+        }
+
+        String jsonFilePath = args[0]; // Get JSON file from command-line arguments
+        decide(jsonFilePath);
     }
 
-    public static void decide() {
+    public static void decide(String jsonFilePath) {
         // Load JSON input from a file
-        InputHandler inputHandler = new InputHandlerImpl("src/main/java/com/dd2480/input1.json");
+        InputHandler inputHandler = new InputHandlerImpl(jsonFilePath);
 
         try {
             inputHandler.processInput();


### PR DESCRIPTION
# Pull Request: User specifies path to input file

## Description
Allows more flexibility in running the program. Not a huge change so if there are any other ideas regarding this we can go with that as well.

- Instead of the decide function having a hardcoded path to input file, a path is passed as a parameter. Path is passed in main function from ``String[] args`` through command line. 
- Does not affect the program testing implemented in AppTest.java.
- Usage (added in docs/maven_commands.md):
    -  lin/mac: ``mvn exec:java -Dexec.args="src/test/resources/test_input1.json"``
    -  windows: ``mvn exec:java -D"exec.args"="src\test\resources\test_input1.json"``


## Type of change
- [ ] Bug fix
- [x] New feature
- [x] Documentation update
- [ ] Refactor
- [ ] Other (please describe)

## How Has This Been Tested?

- [ ] Unit tests
- [ ] Integration tests
- [x] Manual testing

## Checklist
- [x] My code follows the project's coding style guidelines
- [x] I have tested the changes locally
- [x] I have updated the documentation (if necessary)
- [x] I have added tests to cover my changes (if applicable)
- [x] I have checked for any issues in the code base (e.g., linting errors, warnings)

## Related Issues

- Closes #63 

## Additional Notes
Could be possible to have a default path to still have ``mvn exec:java`` as a viable command but not implemented now.
