### PR TITLE
fix: inputhandler test not failing on windows (#97)

### DIFF
--- a/src/test/java/com/dd2480/inputoutput/impl/InputHandlerImplTest.java
+++ b/src/test/java/com/dd2480/inputoutput/impl/InputHandlerImplTest.java
@@ -26,7 +26,7 @@ public class InputHandlerImplTest {
         // Get the file from the resources folder
         InputStream inputStream = getClass().getClassLoader().getResourceAsStream(fileNameNormalfile);
         // If you need to get the full path (e.g., for processing or passing as argument)
-        Path filePath = Paths.get(Main.class.getClassLoader().getResource(fileNameNormalfile).getPath());
+        Path filePath = Paths.get(System.getProperty("user.dir"), "src", "test", "resources", fileNameNormalfile);
 
         // Ensure the file is found in the resources folder
         assertNotNull(inputStream, "The normal input.json file should exist in the resources folder.");
@@ -41,7 +41,7 @@ public class InputHandlerImplTest {
         // Get the file from the resources folder
         InputStream inputStream = getClass().getClassLoader().getResourceAsStream(fileName);
         // If you need to get the full path (e.g., for processing or passing as argument)
-        Path filePath = Paths.get(Main.class.getClassLoader().getResource(fileName).getPath());
+        Path filePath =  Paths.get(System.getProperty("user.dir"), "src", "test", "resources", fileName);
 
 
         // Setup
@@ -60,7 +60,7 @@ public class InputHandlerImplTest {
     public void testGetInputDataWithoutProcessing() {
         String fileName = "test_input1.json";
         // Get the file from the resources folder
-        Path filePath = Paths.get(Main.class.getClassLoader().getResource(fileName).getPath());
+        Path filePath = Paths.get(System.getProperty("user.dir"), "src", "test", "resources", fileName);
 
 
         // Setup
@@ -76,7 +76,7 @@ public class InputHandlerImplTest {
 
         String fileName = "invalid_input.json";
         // Try to process input and check if the exception is handled
-        Path filePath = Paths.get(Main.class.getClassLoader().getResource(fileName).getPath());
+        Path filePath = Paths.get(System.getProperty("user.dir"), "src", "test", "resources", fileName);
 
         inputHandler = new InputHandlerImpl(filePath.toString());
         assertThrows(Exception.class, () -> inputHandler.processInput());


### PR DESCRIPTION
# Pull Request 

## Description
- Running unit tests on inputHandlerImlpTest causes error on windows due to some code where a path to a file is fetched in a way that seems incompatible with windows.
- Now it should be using a cross platform method that doesn't crash on windows and should work on other OS's if it passes the github workflow tests.

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Other (please describe)

## How Has This Been Tested?

- [x] Unit tests
- [ ] Integration tests
- [ ] Manual testing

## Checklist
- [x] My code follows the project's coding style guidelines
- [x] I have tested the changes locally
- [x] I have updated the documentation (if necessary)
- [x] I have added tests to cover my changes (if applicable)
- [x] I have checked for any issues in the code base (e.g., linting errors, warnings)


## Related Issues

- Closes #97

