### PR TITLE
Doc/87 add missing javadoc comments in code

### DIFF
--- a/src/main/java/com/dd2480/CMV/Condition.java
+++ b/src/main/java/com/dd2480/CMV/Condition.java
@@ -1,5 +1,14 @@
 package com.dd2480.CMV;
 
+/**
+ * Interface for each LIC.
+ */
 public interface Condition {
-    boolean evaluate(ConditionContext conditionContext);
+    /**
+     * Evaluates the condition based on the provided context.
+     *
+     * @param context the context in which the condition is evaluated
+     * @return true if the condition is met, false otherwise
+     */
+    boolean evaluate(ConditionContext context);
 }

--- a/src/main/java/com/dd2480/CMV/ConditionContext.java
+++ b/src/main/java/com/dd2480/CMV/ConditionContext.java
@@ -3,8 +3,22 @@ package com.dd2480.CMV;
 import com.dd2480.common.Parameters;
 import com.dd2480.common.PointCollection;
 
+/**
+ * Interface for providing context to condition evaluations, 
+ * which are the parameters and points of the decide problem.
+ */
 public interface ConditionContext {
+    /**
+     * Returns the parameters used in the condition evaluation.
+     *
+     * @return the parameters
+     */
     Parameters getParameters();
+
+    /**
+     * Returns the point collection used in the condition evaluation.
+     *
+     * @return the point collection
+     */
     PointCollection getPointCollection();
-    // Add more methods if needed for additional parameters
 }

--- a/src/main/java/com/dd2480/CMV/ConditionManager.java
+++ b/src/main/java/com/dd2480/CMV/ConditionManager.java
@@ -2,13 +2,11 @@ package com.dd2480.CMV;
 
 import java.util.List;
 
+/**
+ * Interface for managing and evaluating conditions.
+ */
 public interface ConditionManager {
     List<Condition> getConditions();
-
     List<Boolean> getConditionMetVector();
-
-
     void evaluateAll(ConditionContext conditionContext);
-
-
 }

--- a/src/main/java/com/dd2480/CMV/impl/ConditionContextImpl.java
+++ b/src/main/java/com/dd2480/CMV/impl/ConditionContextImpl.java
@@ -4,13 +4,25 @@ import com.dd2480.CMV.ConditionContext;
 import com.dd2480.common.Parameters;
 import com.dd2480.common.PointCollection;
 
+/**
+ * Implementation of the ConditionContext interface.
+ * This class holds the parameters and point collection used for condition evaluation.
+ */
 public class ConditionContextImpl implements ConditionContext {
     private final Parameters params;
     private final PointCollection pointCollection;
+
+    /**
+     * Constructs a ConditionContextImpl with the specified parameters and point collection.
+     *
+     * @param parameters the parameters to be used
+     * @param pointCollection the point collection to be used
+     */
     public ConditionContextImpl(Parameters parameters, PointCollection pointCollection) {
         this.params = parameters;
         this.pointCollection = pointCollection;
     }
+
     @Override
     public Parameters getParameters() {
         return params;

--- a/src/main/java/com/dd2480/CMV/impl/ConditionEight.java
+++ b/src/main/java/com/dd2480/CMV/impl/ConditionEight.java
@@ -7,7 +7,8 @@ import com.dd2480.common.PointCollection;
 import com.dd2480.common.Parameters;
 import com.dd2480.common.CalculationUtils;
 
-/*
+/**
+ * LIC 8:
  * There exists at least one set of three data points separated by exactly A_PTS and B_PTS
  * consecutive intervening points, respectively, that cannot be contained within or on a circle of
  * radius RADIUS1. The condition is not met when NUMPOINTS < 5.

--- a/src/main/java/com/dd2480/CMV/impl/ConditionEleven.java
+++ b/src/main/java/com/dd2480/CMV/impl/ConditionEleven.java
@@ -6,7 +6,8 @@ import com.dd2480.common.Point;
 import com.dd2480.common.PointCollection;
 import com.dd2480.common.Parameters;
 
-/*
+/**
+ * LIC 11:
  * There exists at least one set of two data points, (X[i],Y[i]) and (X[j],Y[j]), separated by
  * exactly G_PTS consecutive intervening points, such that X[j] - X[i] < 0. (where i < j ) 
  * The condition is not met when NUMPOINTS < 3.

--- a/src/main/java/com/dd2480/CMV/impl/ConditionFive.java
+++ b/src/main/java/com/dd2480/CMV/impl/ConditionFive.java
@@ -5,7 +5,8 @@ import com.dd2480.CMV.ConditionContext;
 import com.dd2480.common.Point;
 import com.dd2480.common.PointCollection;
 
-/*
+/**
+ * LIC 5:
  * There exists at least one set of two consecutive data points, (X[i],Y[i]) and (X[j],Y[j]), such
  * that X[j] - X[i] < 0. (where i = j-1)
  */

--- a/src/main/java/com/dd2480/CMV/impl/ConditionFour.java
+++ b/src/main/java/com/dd2480/CMV/impl/ConditionFour.java
@@ -11,7 +11,8 @@ import com.dd2480.common.Parameters;
 import java.util.HashSet;
 import java.util.Set;
 
-/*
+/**
+ * LIC 4:
  * There exists at least one set of Q_PTS consecutive data points that lie in more than QUADS
  * quadrants. Where there is ambiguity as to which quadrant contains a given point, priority
  * of decision will be by quadrant number, i.e., I, II, III, IV. For example, the data point (0,0)

--- a/src/main/java/com/dd2480/CMV/impl/ConditionFourteen.java
+++ b/src/main/java/com/dd2480/CMV/impl/ConditionFourteen.java
@@ -7,9 +7,8 @@ import com.dd2480.common.PointCollection;
 import com.dd2480.common.CalculationUtils;
 import com.dd2480.common.Parameters;
 
-/*
- * Class that handles the fourteenth CMV condition
- * 
+/**
+ * LIC 14:
  * There exists at least one set of three data points, separated by exactly E PTS and F PTS consecutive 
  * intervening points, respectively, that are the vertices of a triangle with area greater than AREA1. 
  * In addition, there exist three data points (which can be the same or different from the three data points 

--- a/src/main/java/com/dd2480/CMV/impl/ConditionManagerImpl.java
+++ b/src/main/java/com/dd2480/CMV/impl/ConditionManagerImpl.java
@@ -11,11 +11,22 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 
+/**
+ * Implementation of the ConditionManager interface.
+ * Manages and evaluates a list of conditions (LICs).
+ */
 public class ConditionManagerImpl implements ConditionManager {
     private final int conditionNumber = 15;
     private final List<Condition> conditions;
     public List<Boolean> conditionMetVector;
 
+    /**
+     * Constructs a ConditionManagerImpl that stores a list of the conditions and
+     * creates a conditions met vector (CMV) which can be computed using the 
+     * evaluateAll method of the ConditionManagerImpl.
+     *
+     * @param conditions the list of conditions to be managed
+     */
     public ConditionManagerImpl(List<Condition> conditions) {
         this.conditions = conditions;
         int numberConditions = conditions.size();
@@ -34,6 +45,12 @@ public class ConditionManagerImpl implements ConditionManager {
         return conditionMetVector;
     }
 
+    /**
+     * Evaluates all conditions by calling their respective evaluate function,
+     * based on the provided context. 
+     *
+     * @param conditionContext the context in which the conditions are evaluated
+     */
     public void evaluateAll(ConditionContext conditionContext) {
         for (int i = 0; i < conditions.size(); ++i) {
             if (conditions.get(i).evaluate(conditionContext)) {

--- a/src/main/java/com/dd2480/CMV/impl/ConditionNine.java
+++ b/src/main/java/com/dd2480/CMV/impl/ConditionNine.java
@@ -7,7 +7,8 @@ import com.dd2480.common.PointCollection;
 import com.dd2480.common.CalculationUtils;
 import com.dd2480.common.Parameters;
 
-/*
+/**
+ * LIC 9:
  * There exists at least one set of three data points separated by exactly C_PTS and D_PTS
  * consecutive intervening points, respectively, that form an angle such that:
  * angle < (PI−EPSILON)

--- a/src/main/java/com/dd2480/CMV/impl/ConditionOne.java
+++ b/src/main/java/com/dd2480/CMV/impl/ConditionOne.java
@@ -7,11 +7,11 @@ import com.dd2480.common.Point;
 import com.dd2480.common.PointCollection;
 import com.dd2480.common.CalculationUtils;
 
-/*
+/**
+ * LIC 1:
  * There exists at least one set of three consecutive data points 
  * that cannot all be contained within or on a circle of radius RADIUS1.
  */
-
 public class ConditionOne implements Condition {
     @Override
     public boolean evaluate(ConditionContext conditionContext) {

--- a/src/main/java/com/dd2480/CMV/impl/ConditionSeven.java
+++ b/src/main/java/com/dd2480/CMV/impl/ConditionSeven.java
@@ -7,7 +7,8 @@ import com.dd2480.common.PointCollection;
 import com.dd2480.common.CalculationUtils;
 import com.dd2480.common.Parameters;
 
-/*
+/**
+ * LIC 7:
  * There exists at least one set of two data points separated by exactly K_PTS 
  * consecutive intervening points that are a distance greater than the length, 
  * LENGTH1, apart. The condition is not met when NUMPOINTS < 3.

--- a/src/main/java/com/dd2480/CMV/impl/ConditionSix.java
+++ b/src/main/java/com/dd2480/CMV/impl/ConditionSix.java
@@ -7,7 +7,8 @@ import com.dd2480.common.PointCollection;
 import com.dd2480.common.CalculationUtils;
 import com.dd2480.common.Parameters;
 
-/*
+/**
+ * LIC 6: 
  * There exists at least one set of N_PTS consecutive data points such that at least one of the
  * points lies a distance greater than DIST from the line joining the first and last of these N PTS
  * points. If the first and last points of these N PTS are identical, then the calculated distance

--- a/src/main/java/com/dd2480/CMV/impl/ConditionTen.java
+++ b/src/main/java/com/dd2480/CMV/impl/ConditionTen.java
@@ -7,7 +7,8 @@ import com.dd2480.common.PointCollection;
 import com.dd2480.common.CalculationUtils;
 import com.dd2480.common.Parameters;
 
-/*
+/**
+ * LIC 10:
  * There exists at least one set of three data points separated by exactly E_PTS and F_PTS 
  * consecutive intervening points, respectively, that are the vertices of a triangle with 
  * area greater than AREA1. The condition is not met when NUMPOINTS < 5. 

--- a/src/main/java/com/dd2480/CMV/impl/ConditionThirteen.java
+++ b/src/main/java/com/dd2480/CMV/impl/ConditionThirteen.java
@@ -7,15 +7,17 @@ import com.dd2480.common.Point;
 import com.dd2480.common.PointCollection;
 import com.dd2480.common.CalculationUtils;
 
-// There exists at least one set of three data points, separated by exactly A PTS and B PTS
-// consecutive intervening points, respectively, that cannot be contained within or on a circle of
-// radius RADIUS1. In addition, there exists at least one set of three data points (which can be
-// the same or different from the three data points just mentioned) separated by exactly A PTS
-// and B PTS consecutive intervening points, respectively, that can be contained in or on a
-// circle of radius RADIUS2. Both parts must be true for the LIC to be true. The condition is
-// not met when NUMPOINTS < 5.
-// 0 ≤ RADIUS2
-
+/**
+ * LIC 13:
+ * There exists at least one set of three data points, separated by exactly A PTS and B PTS
+ * consecutive intervening points, respectively, that cannot be contained within or on a circle of
+ * radius RADIUS1. In addition, there exists at least one set of three data points (which can be
+ * the same or different from the three data points just mentioned) separated by exactly A PTS
+ * and B PTS consecutive intervening points, respectively, that can be contained in or on a
+ * circle of radius RADIUS2. Both parts must be true for the LIC to be true. The condition is
+ * not met when NUMPOINTS < 5.
+ * 0 ≤ RADIUS2
+ */
 public class ConditionThirteen implements Condition{
 
     @Override

--- a/src/main/java/com/dd2480/CMV/impl/ConditionThree.java
+++ b/src/main/java/com/dd2480/CMV/impl/ConditionThree.java
@@ -7,7 +7,8 @@ import com.dd2480.common.PointCollection;
 import com.dd2480.common.CalculationUtils;
 import com.dd2480.common.Parameters;
 
-/*
+/**
+ * LIC 3:
  * There exists at least one set of three consecutive data points that are the vertices of a triangle
  * with area greater than AREA1.
  */

--- a/src/main/java/com/dd2480/CMV/impl/ConditionTwelve.java
+++ b/src/main/java/com/dd2480/CMV/impl/ConditionTwelve.java
@@ -17,7 +17,8 @@ import com.dd2480.common.Parameters;
  * 0 <= LENGTH2
  */
 public class ConditionTwelve implements Condition {
-    /*
+    /**
+     * LIC 12:
      * Condition A: There exists at least one pair of points separated by exactly
      * KPTS
      * such that the distance between the points is greater than LENGTH1.

--- a/src/main/java/com/dd2480/CMV/impl/ConditionTwo.java
+++ b/src/main/java/com/dd2480/CMV/impl/ConditionTwo.java
@@ -7,7 +7,8 @@ import com.dd2480.common.Parameters;
 import com.dd2480.common.Point;
 import com.dd2480.common.PointCollection;
 
-/*
+/**
+ * LIC 2:
  * There exists at least one set of three consecutive data points which form an angle such that:
  * angle < (PI−EPSILON)
  * or

--- a/src/main/java/com/dd2480/CMV/impl/ConditionZero.java
+++ b/src/main/java/com/dd2480/CMV/impl/ConditionZero.java
@@ -8,9 +8,10 @@ import com.dd2480.common.Point;
 import com.dd2480.common.PointCollection;
 
 
-/*
-There exists at least one set of two consecutive data points that are a distance greater than
-the length, LENGTH1, apart.
+/**
+ * Class for evaluating LIC 0, which reads:
+ * There exists at least one set of two consecutive data points that are a distance greater than
+ * the length, LENGTH1, apart.
  */
 public class ConditionZero implements Condition {
     @Override

--- a/src/main/java/com/dd2480/common/CalculationUtils.java
+++ b/src/main/java/com/dd2480/common/CalculationUtils.java
@@ -1,10 +1,17 @@
 package com.dd2480.common;
 
+/**
+ * Utility class for various recurring calculations in the CMV module.
+ */
 public class CalculationUtils {
 
-    // Double compare as specified in lab assignment
-    public enum CompType { LT, EQ, GT }
-    
+    /**
+     * Compares two double values as specified is lab assignment.
+     *
+     * @param A the first double value
+     * @param B the second double value
+     * @return the comparison type (LT, EQ, GT)
+     */
     public static CompType doubleCompare(double A, double B) {
         final double EPSILON = 0.000001; 
 
@@ -13,8 +20,20 @@ public class CalculationUtils {
         }
         return (A < B) ? CompType.LT : CompType.GT; // Return LT if A < B, otherwise GT
     }
+    /**
+     * Enumeration for comparison types.
+     */
+    public enum CompType { LT, EQ, GT }
+    
 
-    // Calculate the circumcircle radius
+    /**
+     * Calculates the circumcircle radius for three points.
+     *
+     * @param p1 the first point
+     * @param p2 the second point
+     * @param p3 the third point
+     * @return the circumcircle radius
+     */
     public static double calculateCircumcircleRadius(Point p1, Point p2, Point p3) {
         double a = Point.distanceOf(p1, p2);
         double b = Point.distanceOf(p2, p3);
@@ -34,7 +53,14 @@ public class CalculationUtils {
         return (a * b * c) / (4.0 * area);
     }
 
-    // Determine whether the points are collinear or not
+    /**
+     * Determines whether the points are collinear.
+     *
+     * @param p1 the first point
+     * @param p2 the second point
+     * @param p3 the third point
+     * @return true if the points are collinear, false otherwise
+     */
     private static boolean areCollinear(Point p1, Point p2, Point p3) {
         // By area, collinear if the area is zero
         return Math.abs(
@@ -43,6 +69,14 @@ public class CalculationUtils {
                         p3.getX() * (p1.getY() - p2.getY())) / 2.0) < 1e-6; // threshold
     }
 
+    /**
+     * Calculates the area of a triangle formed by three points.
+     *
+     * @param p1 the first point
+     * @param p2 the second point
+     * @param p3 the third point
+     * @return the area of the triangle
+     */
     public static double calculateTriangleArea(Point p1, Point p2, Point p3) {
         return 0.5 * Math.abs(
                 p1.getX() * (p2.getY() - p3.getY()) +
@@ -50,8 +84,14 @@ public class CalculationUtils {
                 p3.getX() * (p1.getY() - p2.getY()));
     }
 
-    // Calculates the angle formed by three points (p1, p2, p3) where p2 is the
-    // vertex.
+    /**
+     * Calculates the angle formed by three points where the second point is the vertex.
+     *
+     * @param p1 the first point
+     * @param p2 the vertex point
+     * @param p3 the third point
+     * @return the angle in radians
+     */
     public static double calculateAngle(Point p1, Point p2, Point p3) {
         // Vectors from the vertex to the other two points
         double v1x = p1.getX() - p2.getX();

--- a/src/main/java/com/dd2480/common/Connector.java
+++ b/src/main/java/com/dd2480/common/Connector.java
@@ -1,5 +1,8 @@
 package com.dd2480.common;
 
+/**
+ * Enum representing logical connectors used in the PUM module.
+ */
 public enum Connector {
     NOTUSED(777),
     ORR(778), // Automatically increments after NOTUSED if desired

--- a/src/test/java/com/dd2480/CMV/impl/ConditionEightTest.java
+++ b/src/test/java/com/dd2480/CMV/impl/ConditionEightTest.java
@@ -11,7 +11,7 @@ import com.dd2480.common.PointCollection;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-/*
+/**
  * Test the 8th condition by one valid test case and two invalid test cases, 
  * one invalid test case is "Add points to form a triple that can be included in RADIUS1" and 
  * the other is "NUMPOINTS < 5"

--- a/src/test/java/com/dd2480/CMV/impl/ConditionElevenTest.java
+++ b/src/test/java/com/dd2480/CMV/impl/ConditionElevenTest.java
@@ -11,7 +11,7 @@ import com.dd2480.common.PointCollection;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-/*
+/**
  * Test the 11th condition by one valid test case and three invalid test cases, 
  * one invalid test case is "Add points such that X[j] - X[i] >= 0" and 
  * the 2nd is "NUMPOINTS < 3" and

--- a/src/test/java/com/dd2480/CMV/impl/ConditionFiveTest.java
+++ b/src/test/java/com/dd2480/CMV/impl/ConditionFiveTest.java
@@ -10,7 +10,7 @@ import com.dd2480.common.PointCollection;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-/*
+/**
  * Test the 5th condition by one valid test case and three invalid test cases, 
  * one invalid test case is "Add points, do NOT meet the condition X[j] - X[i] < 0" and 
  * the 2nd is "NUMPOINTS < 2"

--- a/src/test/java/com/dd2480/CMV/impl/ConditionFourTest.java
+++ b/src/test/java/com/dd2480/CMV/impl/ConditionFourTest.java
@@ -11,7 +11,7 @@ import com.dd2480.common.PointCollection;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-/*
+/**
  * Test the 4th condition by one valid test case and two invalid test cases, 
  * one invalid test case is "Add points, distributed in the same quadrant" and 
  * the other is "Add points less than Q_PTS".

--- a/src/test/java/com/dd2480/CMV/impl/ConditionFourteenTest.java
+++ b/src/test/java/com/dd2480/CMV/impl/ConditionFourteenTest.java
@@ -11,7 +11,7 @@ import com.dd2480.common.PointCollection;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-/*
+/**
  * Test the 14th condition by one valid test case and four invalid test cases, 
  * one invalid test case is "Form triangles not meeting AREA1 but meeting AREA2" and 
  * the 2nd is "Add points that form triangles meeting AREA1 but not AREA2"

--- a/src/test/java/com/dd2480/CMV/impl/ConditionManagerImplTest.java
+++ b/src/test/java/com/dd2480/CMV/impl/ConditionManagerImplTest.java
@@ -9,6 +9,9 @@ import java.lang.reflect.Constructor;
 import java.util.Set;
 
 public class ConditionManagerImplTest {
+    /**
+     * Tests the instantiation of condition classes using reflection.
+     */
     @Test
     public void testClassScanAndInstantiate() {
         // Use Reflections to scan for classes implementing Condition in the 'impl' package

--- a/src/test/java/com/dd2480/CMV/impl/ConditionNineTest.java
+++ b/src/test/java/com/dd2480/CMV/impl/ConditionNineTest.java
@@ -11,7 +11,7 @@ import com.dd2480.common.PointCollection;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-/*
+/**
  * Test the 9th condition by one valid test case and three invalid test cases, 
  * one invalid test case is "Add points that form an angle within the range (PI - EPSILON, PI + EPSILON)" and 
  * the 2nd is "NUMPOINTS < 5"

--- a/src/test/java/com/dd2480/CMV/impl/ConditionOneTest.java
+++ b/src/test/java/com/dd2480/CMV/impl/ConditionOneTest.java
@@ -11,7 +11,7 @@ import com.dd2480.common.PointCollection;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-/*
+/**
  * Test the 1st condition by one valid test case and two invalid test cases, 
  * one invalid test case is "Add points that all fit within a circle of radius RADIUS1" and 
  * the 2nd is "NUMPOINTS < 3".

--- a/src/test/java/com/dd2480/CMV/impl/ConditionSevenTest.java
+++ b/src/test/java/com/dd2480/CMV/impl/ConditionSevenTest.java
@@ -11,7 +11,7 @@ import com.dd2480.common.PointCollection;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-/*
+/**
  * Test the 7th condition by one valid test case and three invalid test cases, 
  * one invalid test case is "The distance between two points less than LENGHTH1" and 
  * the 2nd is "NUMPOINTS < 3" and

--- a/src/test/java/com/dd2480/CMV/impl/ConditionSixTest.java
+++ b/src/test/java/com/dd2480/CMV/impl/ConditionSixTest.java
@@ -11,7 +11,7 @@ import com.dd2480.common.PointCollection;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-/*
+/**
  * Test the 6th condition by one valid test case and two invalid test cases, 
  * one invalid test case is "Add points, all of which have a distance from the line 
  *  less than or equal to DIST" and 

--- a/src/test/java/com/dd2480/CMV/impl/ConditionTenTest.java
+++ b/src/test/java/com/dd2480/CMV/impl/ConditionTenTest.java
@@ -11,7 +11,7 @@ import com.dd2480.common.PointCollection;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-/*
+/**
  * Test the 10th condition by one valid test case and two invalid test cases, 
  * one invalid test case is "Add points that form a triangle with an area less than or equal to AREA1" and 
  * the 2nd is "NUMPOINTS < 5".

--- a/src/test/java/com/dd2480/CMV/impl/ConditionThirteenTest.java
+++ b/src/test/java/com/dd2480/CMV/impl/ConditionThirteenTest.java
@@ -12,7 +12,7 @@ import com.dd2480.common.Parameters;
 import com.dd2480.common.Point;
 import com.dd2480.common.PointCollection;
 
-/*
+/**
  * Test the 13th condition by one valid test case and four invalid test cases, 
  * one invalid test case is "Points 0, 2 and 4 are collinear and can be contained 
  *  on a circle of radius 1" and 

--- a/src/test/java/com/dd2480/CMV/impl/ConditionThreeTest.java
+++ b/src/test/java/com/dd2480/CMV/impl/ConditionThreeTest.java
@@ -11,7 +11,7 @@ import com.dd2480.common.PointCollection;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-/*
+/**
  * Test the 3rd condition by one valid test case and two invalid test cases, 
  * one invalid test case is "Add points, the triangle area is 1" and 
  * the 2nd is "NUMPOINTS < 3".

--- a/src/test/java/com/dd2480/CMV/impl/ConditionTwelveTest.java
+++ b/src/test/java/com/dd2480/CMV/impl/ConditionTwelveTest.java
@@ -11,7 +11,7 @@ import com.dd2480.common.PointCollection;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-/*
+/**
  * Test the 12th condition by one valid test case and two invalid test cases, 
  * one invalid test case is "distance < LENGTH1 (condition A false) while 
  *  distance < LENGTH2 (condition B true)" and 

--- a/src/test/java/com/dd2480/CMV/impl/ConditionTwoTest.java
+++ b/src/test/java/com/dd2480/CMV/impl/ConditionTwoTest.java
@@ -11,7 +11,7 @@ import com.dd2480.common.PointCollection;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-/*
+/**
  * Test the 2nd condition by one valid test case and three invalid test cases, 
  * one invalid test case is "Do not meet either the angle < PI-EPSILON or angle > PI+EPSILON" and 
  * the 2nd is "NUMPOINTS < 3" and 

--- a/src/test/java/com/dd2480/CMV/impl/ConditionZeroTest.java
+++ b/src/test/java/com/dd2480/CMV/impl/ConditionZeroTest.java
@@ -11,7 +11,7 @@ import com.dd2480.common.PointCollection;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-/*
+/**
  * Test the zero condition by one valid test case and two invalid test cases, 
  * one invalid test case is "Distance between the two points <= LENGTH1" and 
  * the 2nd is "NUMPOINTS < 2".


### PR DESCRIPTION
# Pull Request

## Description
Added comments in javadoc style in files where it was lacking, primarily in the CMV module and CalculaitonUtils.

## Type of change
- [ ] Bug fix
- [ ] New feature
- [z] Documentation update
- [ ] Refactor
- [ ] Other (please describe)

## Related Issues

- #87 

